### PR TITLE
Fix image url so it properly loads on https://danger.systems site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [Danger](http://danger.systems/ruby/) plugin. ([RubyGems](https://rubygems.org
 No more set label to issue or pull request manually.  
 Example, you can set labels simply by changing the PR title.
 
-![sample](gif/sample.gif)
+![sample](https://github.com/kaelaela/danger-auto_label/blob/master/gif/sample.gif)
 
 ### Usage
 


### PR DESCRIPTION
Currently the image is not loading on Danger Systems websites (see http://danger.systems/ruby/ under auto-label plugin), as it has a relative path. Setting an absolute path will fix this issue.